### PR TITLE
Make sure newline character is working in confirm messages for FormHelper

### DIFF
--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -176,7 +176,7 @@ class Helper implements EventListenerInterface
      */
     protected function _confirm($message, $okCode, $cancelCode = '', $options = [])
     {
-        $message = str_replace('\n', "\n", json_encode($message));
+        $message = str_replace('\\\n', '\n', json_encode($message));
         $confirm = "if (confirm({$message})) { {$okCode} } {$cancelCode}";
         // We cannot change the key here in 3.x, but the behavior is inverted in this case
         $escape = isset($options['escape']) && $options['escape'] === false;


### PR DESCRIPTION
This was not a correct fix, because the $message = str_replace('\n', "\n", json_encode($message)) do the folowing:

    JSON Encode replaces \n with \n
    str_replace replace \n with real line breaks, but this should not be real line breaks, because they appear in the html source code, javasource needs \n characters so the following line would be the correct fix:

$message = str_replace('\n', 'n', json_encode($message));
or
$message = str_replace('\\\n', '\n', json_encode($message)); // I prefered this one